### PR TITLE
Fix postman collection name

### DIFF
--- a/.github/workflows/postman.yml
+++ b/.github/workflows/postman.yml
@@ -2,6 +2,7 @@ name: Sync OpenAPI specs with Postman
 
 on:
   push:
+    - develop
   workflow_dispatch:
     inputs:
       network_name:

--- a/.github/workflows/postman.yml
+++ b/.github/workflows/postman.yml
@@ -37,7 +37,7 @@ jobs:
           fetch-depth: 0
       - name: Set git tags
         id: gittag
-        run: echo "gittag=$(git describe --tags --dirty" >> $GITHUB_OUTPUT
+        run: echo "test-tag-12345" >> $GITHUB_OUTPUT
 
       # ========== Mapping the network name to postman-related variables ==========
       - name: Map network name to its variables

--- a/.github/workflows/postman.yml
+++ b/.github/workflows/postman.yml
@@ -2,8 +2,6 @@ name: Sync OpenAPI specs with Postman
 
 on:
   push:
-    branches:
-    - main
   workflow_dispatch:
     inputs:
       network_name:
@@ -90,7 +88,7 @@ jobs:
           curl -X GET -H "X-API-KEY:${{secrets.POSTMAN_API_TOKEN}}" https://api.getpostman.com/collections/${{env.gateway_api_collection_id}} > tmp.collection.json
       - name: Update the collection name w/ timestamp and git tag
         run: |
-          sed -i 's/"name":".*","description":"See/"name":"${{env.gateway_api_collection_name}}","description":"See/' tmp.collection.json
+          sed -i 's/"name":".*","description":"This/"name":"${{env.gateway_api_collection_name}}","description":"This/' tmp.collection.json
       - name: Change the baseUrl variable name
         run: |
           sed -i 's/{{baseUrl}}/{{gatewayBaseUrl}}/g' tmp.collection.json

--- a/.github/workflows/postman.yml
+++ b/.github/workflows/postman.yml
@@ -2,8 +2,6 @@ name: Sync OpenAPI specs with Postman
 
 on:
   push:
-    #branches:
-    #  - develop
   workflow_dispatch:
     inputs:
       network_name:
@@ -39,7 +37,7 @@ jobs:
           fetch-depth: 0
       - name: Set git tags
         id: gittag
-        run: echo test-tag-12345 >> $GITHUB_OUTPUT
+        run: echo "gittag=$(git describe --tags --dirty)" >> $GITHUB_OUTPUT
 
       # ========== Mapping the network name to postman-related variables ==========
       - name: Map network name to its variables

--- a/.github/workflows/postman.yml
+++ b/.github/workflows/postman.yml
@@ -2,7 +2,8 @@ name: Sync OpenAPI specs with Postman
 
 on:
   push:
-    - develop
+    branches:
+      - develop
   workflow_dispatch:
     inputs:
       network_name:

--- a/.github/workflows/postman.yml
+++ b/.github/workflows/postman.yml
@@ -39,7 +39,7 @@ jobs:
           fetch-depth: 0
       - name: Set git tags
         id: gittag
-        run: echo "test-tag-12345" >> $GITHUB_OUTPUT
+        run: echo test-tag-12345 >> $GITHUB_OUTPUT
 
       # ========== Mapping the network name to postman-related variables ==========
       - name: Map network name to its variables


### PR DESCRIPTION
Added a missing parenthesis and fixed the `sed` replace command.

The gateway postman collection name is now correct:

<img width="395" alt="image" src="https://user-images.githubusercontent.com/3509654/210362454-2b8cdb78-81dc-437a-ae6a-cb97ac350e70.png">
