### PR TITLE
fix: All unreferenced ancestors are now cached

### DIFF
--- a/src/RadixDlt.NetworkGateway.PostgresIntegration/LedgerExtension/PostgresLedgerExtenderService.cs
+++ b/src/RadixDlt.NetworkGateway.PostgresIntegration/LedgerExtension/PostgresLedgerExtenderService.cs
@@ -553,7 +553,7 @@ WHERE id IN(
 
             dbReadDuration += sw.Elapsed;
 
-            foreach (var knownDbEntity in knownDbEntities.Values.Where(e => e.GlobalAddress != null))
+            foreach (var knownDbEntity in knownDbEntities.Values)
             {
                 var entityType = knownDbEntity switch
                 {
@@ -606,6 +606,8 @@ WHERE id IN(
                 re.Resolve(dbEntity);
                 entitiesToAdd.Add(dbEntity);
             }
+
+            referencedEntities.OnAllEntitiesAreResolved();
 
             foreach (var (childAddress, parentAddress) in childToParentEntities)
             {


### PR DESCRIPTION
The key change that fixed it was the change on line 556 of src/RadixDlt.NetworkGateway.PostgresIntegration/LedgerExtension/PostgresLedgerExtenderService.cs - notably, there was an ancestor chain of Vault > KeyValueStoreEntity1 > KeyValueStoreEntity2 > GlobalComponent.

`KeyValueStoreEntity2` was not referenced by the state changes at all, and was not global. So, despite being loaded as a `knownDbEntity`, it wasn't actually "Resolved" against the `ReferencedEntityDictionary`.

This now fixes it. The other changes are minor refactors / renames that I made as part of understanding the issue.

See slack for discussion.