### PR TITLE
DO-1167 - use AWS to fetch Dockerhub credentials

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -83,11 +83,24 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
 
+      - name: "Configure AWS credentials"
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          role-to-assume: arn:aws:iam::308190735829:role/gh-dockerhub-releaser
+          aws-region: eu-west-2
+
+      - name: Read secrets from AWS Secrets Manager into environment variables
+        uses: aws-actions/aws-secretsmanager-get-secrets@v1
+        with:
+          secret-ids: |
+            DOCKERHUB, github-actions/rdxworks/dockerhub-images/release-credentials
+          parse-json-secrets: true
+
       - name: Login to Dockerhub (release)
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ env.DOCKERHUB_TOKEN }}
 
       - name: Setup tags for docker image
         id: setup_tags


### PR DESCRIPTION
Use Dockerhub credentials from AWS account.

This requires the use of the protected environment release. 
This can only apply to protected branches. (main,releases/**)