### PR TITLE
fix: Fix FormatNonFungibleLocalId formatting

### DIFF
--- a/src/RadixDlt.NetworkGateway.PostgresIntegration/ScryptoSborUtils.cs
+++ b/src/RadixDlt.NetworkGateway.PostgresIntegration/ScryptoSborUtils.cs
@@ -217,7 +217,7 @@ internal static class ScryptoSborUtils
         return "[UnrecognizedMetadataValue]";
     }
 
-    public static String FormatNonFungibleLocalId(ToolkitModel.INonFungibleLocalId nonFungibleLocalId)
+    public static string FormatNonFungibleLocalId(ToolkitModel.INonFungibleLocalId nonFungibleLocalId)
     {
         switch (nonFungibleLocalId)
         {


### PR DESCRIPTION
Fix for NonFungibleGlobalIds being formatted as:
```
resource_tdx_c_1qg7cr2y5ud76qwjxc9sspp9egwefjdklrlx6c8lnyvsqpexmck:String { Value = <string> }
```