### PR TITLE
use build artifacts for Directory.Build.props

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,6 +43,12 @@ jobs:
         with:
           github_event_name: ${{ github.event_name }}
           github_action_name: ${{ github.event.action}}
+      - name: Publish Gateway Settings
+        uses: actions/upload-artifact@v3
+        with:
+          path: Directory.Build.props
+          name: build_props
+          retention-days: 1
 
   docker-database-migrations-gcr:
     name: (DatabaseMigrations) Docker
@@ -58,6 +64,9 @@ jobs:
       context: "."
       dockerfile: "./apps/DatabaseMigrations/Dockerfile"
       platforms: "linux/amd64"
+      restore_artifact: "true"
+      artifact_location: "./"
+      artifact_name: build_props
     secrets:
       workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDP }}
       service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
@@ -76,6 +85,9 @@ jobs:
       context: "."
       dockerfile: "./apps/DataAggregator/Dockerfile"
       platforms: "linux/amd64"
+      restore_artifact: "true"
+      artifact_location: "./"
+      artifact_name: build_props
     secrets:
       workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDP }}
       service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
@@ -94,6 +106,9 @@ jobs:
       context: "."
       dockerfile: "./apps/GatewayApi/Dockerfile"
       platforms: "linux/amd64"
+      restore_artifact: "true"
+      artifact_location: "./"
+      artifact_name: build_props
     secrets:
       workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDP }}
       service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}

--- a/apps/DataAggregator/Dockerfile
+++ b/apps/DataAggregator/Dockerfile
@@ -20,6 +20,5 @@ FROM base AS final
 WORKDIR /app
 COPY --from=publish /app/publish .
 ENTRYPOINT ["dotnet", "DataAggregator.dll"]
-COPY Directory.Build.props .
 
 # TODO use local paths and adjust context for CI/CD

--- a/apps/DataAggregator/Dockerfile
+++ b/apps/DataAggregator/Dockerfile
@@ -20,5 +20,6 @@ FROM base AS final
 WORKDIR /app
 COPY --from=publish /app/publish .
 ENTRYPOINT ["dotnet", "DataAggregator.dll"]
+COPY Directory.Build.props .
 
 # TODO use local paths and adjust context for CI/CD


### PR DESCRIPTION
Adding the modified Directory.Build.props as build artifact. 

Running in different jobs of the same workflow does not guarantee that actions are performed on the same runner. Therefor all changed files should be treated as build artifacts and downloaded during the build step or being modified by the build step itself.

Here is a screenshot of proof that the Directory.Build.props file is correctly edited. This was done using a [dummy commit](https://github.com/radixdlt/babylon-gateway/pull/231/commits/d5592d5e44822e7f145a8d0921b973a9fdf3cb28), that would copy said file into the last stage of the dockerfile as previous stages are not accessible outside the build environment.

This will probably also need to be altered for the release workflow. Which is blocked due to the reusable workflows limitation to only download one artifact.

<img width="1343" alt="Screenshot 2023-03-31 at 08 08 19" src="https://user-images.githubusercontent.com/122281269/229128872-e5f072cf-252d-436b-8dbe-c9e2b944116a.png">
