### PR TITLE
chore: update actions version

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -7,16 +7,11 @@ jobs:
     runs-on: ubuntu-22.04
     environment: release
     steps:
-      - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
       - name: Setup .NET SDK
-        uses: actions/setup-dotnet@607fce577a46308457984d59e4954e075820f10a
+        uses: actions/setup-dotnet@3447fd6a9f9e57506b15f895c5b76d3b197dc7c2
         with:
           dotnet-version: 7.0.x
-      - name: Get release
-        id: get_release
-        uses: bruceadams/get-release@f589ce0779c7bef1faf175f7488c972eb47dc046
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
       - name: Build linux binaries
         run: |
           cd apps/DataAggregator
@@ -44,7 +39,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ steps.get_release.outputs.upload_url }}
+          upload_url: ${{ github.event.release.upload_url }}
           asset_path: ./gateway-api.zip
           asset_name: gateway-api-${{ github.event.release.tag_name }}-linux-x64.zip
           asset_content_type: application/zip
@@ -53,7 +48,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ steps.get_release.outputs.upload_url }}
+          upload_url: ${{ github.event.release.upload_url }}
           asset_path: ./database-migrations.zip
           asset_name: database-migrations-${{ github.event.release.tag_name }}-linux-x64.zip
           asset_content_type: application/zip
@@ -76,7 +71,7 @@ jobs:
           github_event_name: ${{ github.event_name }}
           github_action_name: ${{ github.event.action}}
       - name: Publish Gateway Settings
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
         with:
           path: Directory.Build.props
           name: build_props


### PR DESCRIPTION
get-releases is not maintained and there is an official github solution that provides the same results in an easier way.