### PR TITLE
fix: error IL3000

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -20,11 +20,11 @@ jobs:
       - name: Build linux binaries
         run: |
           cd apps/DataAggregator
-          dotnet publish --runtime linux-x64 --configuration Release --self-contained false -p:PublishSingleFile=true -p:PublishReadyToRun=true -p:DebugType=None -p:DebugSymbols=false --output ./output
+          dotnet publish --runtime linux-x64 --configuration Release --self-contained false -p:PublishReadyToRun=true -p:DebugType=None -p:DebugSymbols=false --output ./output
           cd ../DatabaseMigrations
-          dotnet publish --runtime linux-x64 --configuration Release --self-contained false -p:PublishSingleFile=true -p:PublishReadyToRun=true -p:DebugType=None -p:DebugSymbols=false --output ./output
+          dotnet publish --runtime linux-x64 --configuration Release --self-contained false -p:PublishReadyToRun=true -p:DebugType=None -p:DebugSymbols=false --output ./output
           cd ../GatewayApi
-          dotnet publish --runtime linux-x64 --configuration Release --self-contained false -p:PublishSingleFile=true -p:PublishReadyToRun=true -p:DebugType=None -p:DebugSymbols=false --output ./output
+          dotnet publish --runtime linux-x64 --configuration Release --self-contained false -p:PublishReadyToRun=true -p:DebugType=None -p:DebugSymbols=false --output ./output
           cd ../..
           zip -r data-aggregator.zip apps/DataAggregator/output/
           zip -r database-migrations.zip apps/DatabaseMigrations/output/

--- a/src/RadixDlt.NetworkGateway.PostgresIntegration/Services/LedgerStateQuerier.cs
+++ b/src/RadixDlt.NetworkGateway.PostgresIntegration/Services/LedgerStateQuerier.cs
@@ -241,7 +241,7 @@ internal class LedgerStateQuerier : ILedgerStateQuerier
 
     private static (string FullVersion, string DeployedImage) GetGatewayProductVersion()
     {
-        var productVersion = FileVersionInfo.GetVersionInfo(AppContext.BaseDirectory).ProductVersion;
+        var productVersion = FileVersionInfo.GetVersionInfo(typeof(NetworkGatewayConstants).Assembly.Location).ProductVersion;
         if (productVersion == null)
         {
             throw new InvalidOperationException("Unable to determine product version");

--- a/src/RadixDlt.NetworkGateway.PostgresIntegration/Services/LedgerStateQuerier.cs
+++ b/src/RadixDlt.NetworkGateway.PostgresIntegration/Services/LedgerStateQuerier.cs
@@ -241,7 +241,7 @@ internal class LedgerStateQuerier : ILedgerStateQuerier
 
     private static (string FullVersion, string DeployedImage) GetGatewayProductVersion()
     {
-        var productVersion = FileVersionInfo.GetVersionInfo(typeof(NetworkGatewayConstants).Assembly.Location).ProductVersion;
+        var productVersion = FileVersionInfo.GetVersionInfo(AppContext.BaseDirectory).ProductVersion;
         if (productVersion == null)
         {
             throw new InvalidOperationException("Unable to determine product version");


### PR DESCRIPTION
I have checked through the babylon-gateway release workflow and could not get the build to work. Now I am very bad when it comes to dotnet. Therefor I was hoping for your opinion on this error and fix.

This command:
```
dotnet publish --runtime linux-x64 --self-contained false -p:PublishSingleFile=true -p:PublishReadyToRun=true -p:DebugType=None -p:DebugSymbols=false "apps/DataAggregator/DataAggregator.csproj" -c Release -o /tmp/app/dataaggregator
```
Fails with this error message:
```
/Users/kim.fehrs/projects/rdx/radixdlt-org/babylon-gateway/src/RadixDlt.NetworkGateway.PostgresIntegration/Services/LedgerStateQuerier.cs(244,61): error IL3000: 'System.Reflection.Assembly.Location' always returns an empty string for assemblies embedded in a single-file app. If the path to the app directory is needed, consider calling 'System.AppContext.BaseDirectory'. [/Users/kim.fehrs/projects/rdx/radixdlt-org/babylon-gateway/src/RadixDlt.NetworkGateway.PostgresIntegration/RadixDlt.NetworkGateway.PostgresIntegration.csproj]
```
Which is found [here](https://github.com/radixdlt/babylon-gateway/blob/91fba72f87567a052302955f91cfcc045ca9bb44/src/RadixDlt.NetworkGateway.PostgresIntegration/Services/LedgerStateQuerier.cs#L244).

The search result for the error gave me [this](https://learn.microsoft.com/en-us/dotnet/core/deploying/single-file/warnings/il3000)

And the line would look like this after the proposed fix:

```
var productVersion = FileVersionInfo.GetVersionInfo(AppContext.BaseDirectory).ProductVersion; 
```

Afterward it works for single-file builds with

```
dotnet publish --runtime linux-x64 --self-contained false -p:PublishSingleFile=true -p:PublishReadyToRun=true -p:DebugType=None -p:DebugSymbols=false "apps/DataAggregator/DataAggregator.csproj" -c Release -o /tmp/app/dataaggregator
```