### PR TITLE
fix / wait for multiarch image

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -293,9 +293,9 @@ jobs:
     name: Snyk monitor
     runs-on: ubuntu-latest
     needs:
-      - docker-database-migrations-dockerhub
-      - docker-data-aggregator-dockerhub
-      - docker-gateway-api-dockerhub
+      - join-gateway-images
+      - join-aggregator-images
+      - join-migrations-images
     permissions:
       id-token: write
       pull-requests: read

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -264,9 +264,9 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - setup-tags
-      - docker-database-migrations-dockerhub
-      - docker-data-aggregator-dockerhub
-      - docker-gateway-api-dockerhub
+      - join-gateway-images
+      - join-aggregator-images
+      - join-migrations-images
     permissions:
       id-token: write
       pull-requests: read
@@ -293,9 +293,9 @@ jobs:
     name: Snyk monitor
     runs-on: ubuntu-latest
     needs:
-      - join-gateway-images
-      - join-aggregator-images
-      - join-migrations-images
+      - docker-database-migrations-dockerhub
+      - docker-data-aggregator-dockerhub
+      - docker-gateway-api-dockerhub
     permissions:
       id-token: write
       pull-requests: read


### PR DESCRIPTION
As seen in this workflow, the image is not published by the time the snyk monitoring is started. 
Restarting it afterwards fixes the failing workflow.

This PR aims to solve this issue by waiting for the compound multiarch image before starting the snyk monitoring

https://github.com/radixdlt/babylon-gateway/actions/runs/6279709039/attempts/1
https://github.com/radixdlt/babylon-gateway/actions/runs/6279709039/attempts/2
https://github.com/radixdlt/babylon-gateway/actions/runs/6279709039/attempts/3