### PR TITLE
CVE-2023-4911

### DIFF
--- a/apps/DataAggregator/Dockerfile
+++ b/apps/DataAggregator/Dockerfile
@@ -5,7 +5,7 @@
 FROM mcr.microsoft.com/dotnet/aspnet:7.0-bookworm-slim AS base
 WORKDIR /app
 
-// Fixes CVE-2023-4911 can be removed when we update the base OS image to include this fix
+# Fixes CVE-2023-4911 can be removed when we update the base OS image to include this fix
 RUN apt-get update -y \
   && apt-get -y --no-install-recommends install \    
     libc6=2.36-9+deb12u3 \

--- a/apps/DataAggregator/Dockerfile
+++ b/apps/DataAggregator/Dockerfile
@@ -5,6 +5,13 @@
 FROM mcr.microsoft.com/dotnet/aspnet:7.0-bookworm-slim AS base
 WORKDIR /app
 
+// Fixes CVE-2023-4911 can be removed when we update the base OS image to include this fix
+RUN apt-get update -y \
+  && apt-get -y --no-install-recommends install \    
+    libc6=2.36-9+deb12u3 \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
 FROM mcr.microsoft.com/dotnet/sdk:7.0-bookworm-slim AS build
 WORKDIR /src
 COPY . .

--- a/apps/DatabaseMigrations/Dockerfile
+++ b/apps/DatabaseMigrations/Dockerfile
@@ -5,7 +5,7 @@
 FROM mcr.microsoft.com/dotnet/aspnet:7.0-bookworm-slim AS base
 WORKDIR /app
 
-// Fixes CVE-2023-4911 can be removed when we update the base OS image to include this fix
+# Fixes CVE-2023-4911 can be removed when we update the base OS image to include this fix
 RUN apt-get update -y \
   && apt-get -y --no-install-recommends install \    
     libc6=2.36-9+deb12u3 \

--- a/apps/DatabaseMigrations/Dockerfile
+++ b/apps/DatabaseMigrations/Dockerfile
@@ -5,6 +5,13 @@
 FROM mcr.microsoft.com/dotnet/aspnet:7.0-bookworm-slim AS base
 WORKDIR /app
 
+// Fixes CVE-2023-4911 can be removed when we update the base OS image to include this fix
+RUN apt-get update -y \
+  && apt-get -y --no-install-recommends install \    
+    libc6=2.36-9+deb12u3 \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
 FROM mcr.microsoft.com/dotnet/sdk:7.0-bookworm-slim AS build
 WORKDIR /src
 COPY . .

--- a/apps/GatewayApi/Dockerfile
+++ b/apps/GatewayApi/Dockerfile
@@ -5,6 +5,13 @@
 FROM mcr.microsoft.com/dotnet/aspnet:7.0-bookworm-slim AS base
 WORKDIR /app
 
+// Fixes CVE-2023-4911 can be removed when we update the base OS image to include this fix
+RUN apt-get update -y \
+  && apt-get -y --no-install-recommends install \
+    libc6=2.36-9+deb12u3 \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
 FROM mcr.microsoft.com/dotnet/sdk:7.0-bookworm-slim AS build
 WORKDIR /src
 COPY . .

--- a/apps/GatewayApi/Dockerfile
+++ b/apps/GatewayApi/Dockerfile
@@ -5,9 +5,9 @@
 FROM mcr.microsoft.com/dotnet/aspnet:7.0-bookworm-slim AS base
 WORKDIR /app
 
-// Fixes CVE-2023-4911 can be removed when we update the base OS image to include this fix
+# Fixes CVE-2023-4911 can be removed when we update the base OS image to include this fix
 RUN apt-get update -y \
-  && apt-get -y --no-install-recommends install \
+  && apt-get -y --no-install-recommends install \    
     libc6=2.36-9+deb12u3 \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
https://security-tracker.debian.org/tracker/CVE-2023-4911
```

docker run -it mcr.microsoft.com/dotnet/aspnet:7.0-bookworm-slim ldd --version
ldd (Debian GLIBC 2.36-9+deb12u1) 2.36
Copyright (C) 2022 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
Written by Roland McGrath and Ulrich Drepper.
```