### PR TITLE
gracefuly log exception when either LedgerExntenderService commits tr…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Release Date: _unreleased_
 - Fixed exception thrown on empty validator set in the `/state/validator/list` endpoint.
 - `524` status code returned instead of `500` if request takes longer than configured timeout.
 - Validate if addresses provided in requests to API belong to network it is running on. 
-
+- Fixed `500` status code returned from `/transaction/submit` when Transaction got committed before Gateway was able to store pending transaction node submission result. It'll return 200 status code from now on and log exception as information.
 
 ## 1.2.2
 Release Date: 22.11.2023


### PR DESCRIPTION
…ansaction or resubmission service handles transaction before gateway finishes.