### PR TITLE
make it clear that tx has to fullfill all event_filters.

### DIFF
--- a/src/RadixDlt.NetworkGateway.GatewayApi/gateway-api-schema.yaml
+++ b/src/RadixDlt.NetworkGateway.GatewayApi/gateway-api-schema.yaml
@@ -504,7 +504,7 @@ tags:
 
       * `affected_global_entities_filter` - allows specifying an array of global addresses. If specified, the response will contain transactions that affected all of the given global entities. A global entity is marked as "affected" by a transaction if any of its state (or its descendents' state) was modified as a result of the transaction.
 
-      * `events_filter` - allows filtering the transaction stream to transactions which, for each provided filter, the transaction emitted at least one event which matched that filter. Currently *only* deposit and withdrawal events emitted by an internal vault entity are tracked. For the purpose of filtering, the emitter address is replaced by the global ancestor of the emitter, for example, the top-level account / component which contains the vault which emitted the event.
+      * `events_filter` - allows filtering the transaction stream to transactions which, for each provided filter, the transaction emitted at least one event which matched that filter (In short words emitted at least one event matching each filter). Currently *only* deposit and withdrawal events emitted by an internal vault entity are tracked. For the purpose of filtering, the emitter address is replaced by the global ancestor of the emitter, for example, the top-level account / component which contains the vault which emitted the event.
 
       Each filter is a complex object where you can specify:
       - `event` (required) - the event tag. Currently only the following tags are supported:

--- a/src/RadixDlt.NetworkGateway.GatewayApi/gateway-api-schema.yaml
+++ b/src/RadixDlt.NetworkGateway.GatewayApi/gateway-api-schema.yaml
@@ -504,7 +504,7 @@ tags:
 
       * `affected_global_entities_filter` - allows specifying an array of global addresses. If specified, the response will contain transactions that affected all of the given global entities. A global entity is marked as "affected" by a transaction if any of its state (or its descendents' state) was modified as a result of the transaction.
 
-      * `events_filter` - allows filtering the transaction stream to transactions which, for each provided filter, the transaction emitted at least one event which matched that filter (In short words emitted at least one event matching each filter). Currently *only* deposit and withdrawal events emitted by an internal vault entity are tracked. For the purpose of filtering, the emitter address is replaced by the global ancestor of the emitter, for example, the top-level account / component which contains the vault which emitted the event.
+      * `events_filter` - filters the transaction stream to transactions which emitted at least one event matching each filter (each filter can be satisfied by a different event). Currently *only* deposit and withdrawal events emitted by an internal vault entity are tracked. For the purpose of filtering, the emitter address is replaced by the global ancestor of the emitter, for example, the top-level account / component which contains the vault which emitted the event.
 
       Each filter is a complex object where you can specify:
       - `event` (required) - the event tag. Currently only the following tags are supported:


### PR DESCRIPTION
Jakub was confused when reading docs, I wanted to make it clear that transaction has to fullfill all event filters to be returned. If you have better idea how to phrase it, please fix it.