### PR TITLE
fix reading most recent kv store entries. By mistake we were doing un…

### DIFF
--- a/src/RadixDlt.NetworkGateway.PostgresIntegration/LedgerExtension/KeyValueStoreProcessor.cs
+++ b/src/RadixDlt.NetworkGateway.PostgresIntegration/LedgerExtension/KeyValueStoreProcessor.cs
@@ -139,7 +139,7 @@ internal class KeyValueStoreProcessor
 
     private Task<Dictionary<KeyValueStoreEntryDbLookup, KeyValueStoreEntryHistory>> MostRecentKeyValueStoreEntryHistoryFor()
     {
-        var lookupSet = _changeOrder.ToHashSet();
+        var lookupSet = _changeOrder.Select(x => new KeyValueStoreEntryDbLookup(x.KeyValueStoreEntityId, x.Key)).ToHashSet();
 
         if (!lookupSet.Unzip(
                 x => x.KeyValueStoreEntityId,


### PR DESCRIPTION
…ique on (kv store entity id, key, state version) instead of (kv store entity id, key)