### PR TITLE
ci: fix snyk sbom [DO-2367]

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Generate SBOM # check SBOM can be generated but nothing is done with it
         uses: RDXWorks-actions/snyk-actions/dotnet@master
         with:
-          args: --all-projects --org=${{ env.SNYK_SERVICES_ORG_ID }} --exclude=package.json --format=cyclonedx1.4+json --json-file-output sbom.json
+          args: --all-projects --org=${{ env.SNYK_SERVICES_ORG_ID }} --exclude=package.json --format=cyclonedx1.4+json > sbom.json
           command: sbom
 
   build:

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -374,7 +374,7 @@ jobs:
       - name: Generate SBOM
         uses: RDXWorks-actions/snyk-actions/node@master
         with:
-          args: --all-projects --org=${{ env.SNYK_NETWORK_ORG_ID }} --format=cyclonedx1.4+json --json-file-output sbom.json
+          args: --all-projects --org=${{ env.SNYK_NETWORK_ORG_ID }} --format=cyclonedx1.4+json > sbom.json
           command: sbom
       - name: Upload SBOM
         uses: RDXWorks-actions/action-gh-release@master


### PR DESCRIPTION
`--json-file-output` parameter stopped working properly but the same effect can be achieved with stdout redirect `>`