### PR TITLE
feat: add `networkId` config, change stokenet gateway URL

### DIFF
--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -29,11 +29,13 @@ Calling static `intialize` method from `GatewayApiClient` class will instantiate
 `applicationName` is required purely for statictis purposes and will be added as a request header. Additional fields you can set up are `applicationVersion` and `applicationDappDefinitionAddress`
 
 ```typescript
-import { GatewayApiClient } from '@radixdlt/babylon-gateway-api-sdk'
+import { GatewayApiClient, RadixNetwork } from '@radixdlt/babylon-gateway-api-sdk'
 
 const gatewayApi = GatewayApiClient.initialize({
-  basePath: 'https://mainnet.radixdlt.com',
+  networkId: RadixNetwork.Mainnet,
   applicationName: 'Your dApp Name',
+  applicationVersion: '1.0.0',
+  applicationDappDefinitionAddress: 'account_rdx12y4l35lh2543nfa9pyyzvsh64ssu0dv6fq20gg8suslwmjvkylejgj'
 })
 const { status, transaction, stream, state } = gatewayApi
 ```
@@ -75,9 +77,11 @@ High Level APIs will grow over time as we start encountering repeating patterns 
 
 ## Low Level APIs
 
-Low level APIs are generated automatically based on OpenAPI spec. You can get a good sense of available methods by looking at [Swagger](https://rcnet.radixdlt.com/swagger/index.html). In order to access automatically generated methods you have two options:
+Low level APIs are generated automatically based on OpenAPI spec. You can get a good sense of available methods by looking at [Swagger](https://mainnet.radixdlt.com/swagger/index.html). In order to access automatically generated methods you have two options:
 
 ### Using generated APIs through `innerClient`
+
+When using automatically generated APIs please check method parameter. They're always wrapped object with property matching method name (like in the example below) 
 
 ```typescript
 async function getTransactionStatus(transactionIntentHash: string) {
@@ -119,10 +123,10 @@ Behind the scenes, this library uses the fetch API. If in an environment where `
 Starting from NodeJS 16 `fetch` is available as experimental API. You can e.g. check Gateway API status by using following snippet.
 
 ```typescript
-const { GatewayApiClient } = require('@radixdlt/babylon-gateway-api-sdk')
+const { GatewayApiClient, RadixNetwork } = require('@radixdlt/babylon-gateway-api-sdk')
 
 const gateway = GatewayApiClient.initialize({
-  basePath: 'https://mainnet.radixdlt.com',
+  networkId: RadixNetwork.Mainnet
 })
 gateway.status.getCurrent().then(console.log)
 ```

--- a/sdk/typescript/lib/helpers/networks.ts
+++ b/sdk/typescript/lib/helpers/networks.ts
@@ -35,7 +35,7 @@ export const RadixNetworkConfig: Record<string, NetworkConfig> = {
   Stokenet: {
     networkName: 'Stokenet',
     networkId: RadixNetwork.Stokenet,
-    gatewayUrl: 'https://babylon-stokenet-gateway.radixdlt.com',
+    gatewayUrl: 'https://stokenet.radixdlt.com',
     dashboardUrl: 'https://stokenet-dashboard.radixdlt.com',
   },
   Kisharnet: {

--- a/sdk/typescript/lib/index.ts
+++ b/sdk/typescript/lib/index.ts
@@ -1,3 +1,4 @@
+import { RadixNetworkConfigById } from './helpers/networks'
 import {
   ConfigurationParameters,
   StateApi,
@@ -45,6 +46,12 @@ export type GatewayApiClientSettings = ConfigurationParameters & {
    * Application dApp definition address which can be used for statistics purposes.
    */
   applicationDappDefinitionAddress?: string
+
+  /**
+   * Network ID of the network the client is connecting to. It's used to determine the gateway URL.
+   * It's discarded if `basePath` is provided.
+   */
+  networkId?: number
 }
 
 export class GatewayApiClient {
@@ -54,7 +61,10 @@ export class GatewayApiClient {
   }
 
   private static constructConfiguration(settings: GatewayApiClientSettings) {
-    const basePath = normalizeBasePath(settings?.basePath)
+    const basePath =
+      settings.networkId && !settings.basePath
+        ? RadixNetworkConfigById[settings.networkId].gatewayUrl
+        : normalizeBasePath(settings?.basePath)
     const applicationName = settings?.applicationName ?? 'Unknown'
 
     return new RuntimeConfiguration({

--- a/sdk/typescript/test/state.test.ts
+++ b/sdk/typescript/test/state.test.ts
@@ -24,7 +24,7 @@ describe('State Subapi', () => {
       )
       const gatewayApi = GatewayApiClient.initialize({
         fetchApi: spy,
-        basePath: 'https://just-for-test.com',
+        networkId: 2,
         maxAddressesCount: 1,
       })
 
@@ -34,7 +34,7 @@ describe('State Subapi', () => {
       // Assert
       expect(spy).toHaveBeenCalledTimes(2)
       expect(spy).toHaveBeenCalledWith(
-        'https://just-for-test.com/state/entity/details',
+        'https://stokenet.radixdlt.com/state/entity/details',
         fetchRequestFactory({
           opt_ins: {
             ancestor_identities: false,
@@ -48,7 +48,7 @@ describe('State Subapi', () => {
         })
       )
       expect(spy).toHaveBeenCalledWith(
-        'https://just-for-test.com/state/entity/details',
+        'https://stokenet.radixdlt.com/state/entity/details',
         fetchRequestFactory({
           opt_ins: {
             ancestor_identities: false,
@@ -188,6 +188,7 @@ describe('State Subapi', () => {
       const gatewayApi = GatewayApiClient.initialize({
         fetchApi: spy,
         basePath: 'https://just-for-test.com',
+        networkId: 1,
         maxAddressesCount: 1,
       })
 


### PR DESCRIPTION
## Summary

We want to align how Gateway SDK and Radix dApp Toolkit are instantiated

## Details

We're going to remove Gateway SDK from RDT - people will need to instantiate Gateway API SDK themselves if they want to use it. We want to make it easier for them - there should be no need to know gateway url base path, `networkId` is enough