### PR TITLE
Github actions pass branch name to Jenkins

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -404,7 +404,8 @@ jobs:
             {
               "RADIXDLT_GATEWAY_DOCKER_TAG": "${{ needs.setup-tags.outputs.gateway-api-tag }}",
               "RADIXDLT_NODE_DOCKER_TAG": "${{ env.FULLNODE_VERSION }}",
-              "RADIXDLT_POSTGRES_APP_VERSION": "${{ env.POSTGRES_VERSION }}"
+              "RADIXDLT_POSTGRES_APP_VERSION": "${{ env.POSTGRES_VERSION }}",
+              "testingHarnessBranch": "${{ env.GATEWAY_BRANCH }}"
             }
           job_timeout: "3600"
 


### PR DESCRIPTION
## Summary

The Gateway branch name should be passed to Jenkins, so that Jenkins can check out the same testing-harness branch (or `develop` by default) and use that branch to run tests from

## Testing

Tested manually. The job picks up the branch name: https://jenkins.extratools.works/job/babylon-testing/job/ephemeral-deployments/job/ephemeral-gateway-env-deploy-and-test/544/parameters/